### PR TITLE
Add cmdv2 

### DIFF
--- a/internal/cmdv2/command.go
+++ b/internal/cmdv2/command.go
@@ -1,0 +1,34 @@
+package cmdv2
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+)
+
+type (
+	// Command is an interface that implements the bubbletea.Model interface, as well as returning a
+	// cobra.Command type, so that they can play well together.
+	Command interface {
+		// Command returns the cobra.Command type so that the CLI can be built.
+		Command() *cobra.Command
+
+		// Init implements the bubbletea.Model.Init() interface.
+		Init() tea.Cmd
+
+		// Type returns a unique type string identifying the command.
+		Type() CommandType
+
+		// Update implements the bubbletea.Model.Update() interface.
+		Update(msg tea.Msg) (tea.Model, tea.Cmd)
+
+		// View implements the bubbletea.Model.View() interface.
+		View() string
+	}
+
+	// CommandType is the unique ID for a Command.
+	CommandType string
+)
+
+const (
+	CommandTypeVersion CommandType = "version"
+)

--- a/internal/cmdv2/register.go
+++ b/internal/cmdv2/register.go
@@ -1,0 +1,22 @@
+package cmdv2
+
+import "fmt"
+
+var registeredCommands = []Command{}
+
+// RegisterCommand adds a new Command type to the list of available commands in the CLI.
+func RegisterCommand(command Command) {
+	for _, registeredCommand := range registeredCommands {
+		if registeredCommand.Type() == command.Type() {
+			err := fmt.Errorf("command type already registered: %s", command.Type())
+			panic(err)
+		}
+	}
+
+	registeredCommands = append(registeredCommands, command)
+}
+
+// RegisteredCommands returns all registered Command types in the CLI.
+func RegisteredCommands() []Command {
+	return registeredCommands
+}

--- a/internal/cmdv2/version.go
+++ b/internal/cmdv2/version.go
@@ -1,0 +1,58 @@
+package cmdv2
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/revett/atlas/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RegisterCommand(Version{})
+}
+
+type Version struct {
+	config config.Config
+}
+
+func (v Version) Command() *cobra.Command {
+	return &cobra.Command{
+		Use:                   "version",
+		Short:                 "Print the version",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  v.runE,
+	}
+}
+
+func (v Version) Init() tea.Cmd {
+	return nil
+}
+
+func (v Version) Type() CommandType {
+	return CommandTypeVersion
+}
+
+func (v Version) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
+	return v, tea.Quit
+}
+
+func (v Version) View() string {
+	return v.config.Version
+}
+
+func (v *Version) runE(c *cobra.Command, args []string) error {
+	cfg, ok := c.Context().Value(config.ContextConfigKey).(config.Config)
+	if !ok {
+		return config.ErrContextConfigValueIsNotConfigType
+	}
+
+	v.config = cfg
+
+	if _, err := tea.NewProgram(v).Run(); err != nil {
+		return fmt.Errorf("running tui program: %w", err)
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+// Config stores configuration required by the CLI.
+type Config struct {
+	Version string
+}
+
+// NewConfig creates a new Config type.
+func NewConfig(version string) Config {
+	return Config{
+		Version: version,
+	}
+}

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -1,0 +1,8 @@
+package config
+
+// ContextKey is a dedicated type for accessing context values via a key, to avoid collisions.
+// https://www.calhoun.io/pitfalls-of-context-values-and-how-to-avoid-or-mitigate-them
+type ContextKey string
+
+// ContextConfigKey is the key used to store the Config in a context.Context.
+const ContextConfigKey ContextKey = "atlas.config"

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -1,0 +1,7 @@
+package config
+
+import "errors"
+
+var ErrContextConfigValueIsNotConfigType = errors.New(
+	"context config value cannot be cast to config type",
+)


### PR DESCRIPTION
- New `Command` interface that blends `bubbletea` and `cobra` together
- `config.Config` type to support global state via `context.Context`